### PR TITLE
モーダルウィンドウによる記事投稿・削除・編集の機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ gem 'devise'
 gem 'font-awesome-sass'
 gem 'carrierwave'
 gem 'mini_magick'
+# 削除確認ダイアログをmodal表示
+gem 'data-confirm-modal'
 
 group :development, :test do
   # 以下はvscodeの拡張用

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
+    data-confirm-modal (1.6.2)
+      railties (>= 3.0)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
     debase-ruby_core_source (0.10.6)
@@ -327,6 +329,7 @@ DEPENDENCIES
   carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
+  data-confirm-modal
   debase
   debride
   devise

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,4 +16,5 @@
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets
+//= require data-confirm-modal
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import "module/users";
 @import "module/posts";
 @import "module/post_form";
+@import "module/flash";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,4 +6,3 @@
 @import "module/users";
 @import "module/posts";
 @import "module/post_form";
-@import "module/post_card";

--- a/app/assets/stylesheets/module/_flash.scss
+++ b/app/assets/stylesheets/module/_flash.scss
@@ -1,0 +1,10 @@
+.flash {
+  text-align: center;
+  color: white;
+  &__message--alert {
+    background-color: orange;
+  }
+  &__message--notice {
+    background-color: violet;
+  }
+}

--- a/app/assets/stylesheets/module/_post_card.scss
+++ b/app/assets/stylesheets/module/_post_card.scss
@@ -1,6 +1,0 @@
-.posts__card {
-  &__image {
-    text-align: center;
-    padding: 1rem;
-  }
-}

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -8,6 +8,9 @@
       &__image {
         font-size: 1.8rem;
         margin: 0.5rem;
+        &:hover {
+          cursor: pointer;
+        }
         &__field {
           display: none;
         }

--- a/app/assets/stylesheets/module/_posts.scss
+++ b/app/assets/stylesheets/module/_posts.scss
@@ -17,5 +17,9 @@
         }
       }
     }
+    &__image {
+      text-align: center;
+      padding: 1rem;
+    }
   }
 }

--- a/app/assets/stylesheets/module/_posts.scss
+++ b/app/assets/stylesheets/module/_posts.scss
@@ -11,9 +11,23 @@
         display: flex;
         justify-content: space-between;
         color: grey;
-        a {
-          text-decoration: none;
-          color: grey;
+        &__username {
+          a {
+            text-decoration: none;
+            color: grey;
+          }
+        }
+        &__dropdown {
+          &__btn {
+            margin: 0;
+            padding: 0 0.5rem;
+            border: 0;
+          }
+          &__menu {
+            a {
+              text-decoration: none;
+            }
+          }
         }
       }
     }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,6 +30,10 @@ class PostsController < ApplicationController
   end
 
   def edit
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def update

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,11 +38,18 @@ class PostsController < ApplicationController
 
   def update
     @post.update(post_params)
-    if @post.errors.empty?
-      redirect_to user_path(current_user.id), notice: "メッセージを更新しました"
-    else
-      flash.now[:alert] = "メッセージが入力されていません"
-      render :edit
+
+    respond_to do |format|
+      if @post.errors.empty?
+        format.html {redirect_to user_path(current_user.id), notice: "メッセージを更新しました"}
+        format.js { @status = "success"}
+      else
+        format.html do
+          flash.now[:alert] = "メッセージが入力されていません"
+          render :new
+        end
+        format.js { @status = "fail" }
+      end
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,11 @@ class PostsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+  end
 
   def destroy
     Post.destroy(params[:id])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,6 +7,10 @@ class PostsController < ApplicationController
   end
 
   def new
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,10 +15,17 @@ class PostsController < ApplicationController
 
   def create
     post = Post.create(post_params)
-    if post.errors.empty?
-      redirect_to user_path(current_user.id)
-    else
-      render :new
+    respond_to do |format|
+      format.html do
+        if post.errors.empty?
+          redirect_to user_path(current_user.id), notice: "メッセージを投稿しました"
+        else
+          flash.now[:alert] = "メッセージが入力されていません"
+          render :new
+        end
+      end
+      format.json
+      format.js
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,12 @@ class PostsController < ApplicationController
     end
   end
 
+
+  def destroy
+    Post.destroy(params[:id])
+    redirect_back(fallback_location: root_path)
+  end
+
   private
 
   def set_new_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_new_post, only: [:new, :create]
+  before_action :set_post, only: [:edit, :update]
 
   def index
     @posts = Post.all.includes(:user).order(created_at: :desc)
@@ -21,6 +22,12 @@ class PostsController < ApplicationController
   end
 
   def update
+    @post.update(post_params)
+    if @post.errors.empty?
+      redirect_to user_path(current_user.id)
+    else
+      render :edit
+    end
   end
 
   def destroy
@@ -32,6 +39,10 @@ class PostsController < ApplicationController
 
   def set_new_post
     @post = Post.new
+  end
+
+  def set_post
+    @post = Post.find(params[:id])
   end
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,8 +35,9 @@ class PostsController < ApplicationController
   def update
     @post.update(post_params)
     if @post.errors.empty?
-      redirect_to user_path(current_user.id)
+      redirect_to user_path(current_user.id), notice: "メッセージを更新しました"
     else
+      flash.now[:alert] = "メッセージが入力されていません"
       render :edit
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,18 +14,18 @@ class PostsController < ApplicationController
   end
 
   def create
-    post = Post.create(post_params)
+    @post_latest = Post.create(post_params)
     respond_to do |format|
-      format.html do
-        if post.errors.empty?
-          redirect_to user_path(current_user.id), notice: "メッセージを投稿しました"
-        else
+      if @post_latest.errors.empty?
+        format.html { redirect_to user_path(current_user.id), notice: "メッセージを投稿しました" }
+        format.js { @status = "success"}
+      else
+        format.html do
           flash.now[:alert] = "メッセージが入力されていません"
           render :new
         end
+        format.js { @status = "fail" }
       end
-      format.json
-      format.js
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -54,8 +54,17 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    Post.destroy(params[:id])
-    redirect_back(fallback_location: root_path)
+    @post_destroyed = Post.destroy(params[:id])
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: root_path) }
+      format.js do
+        if @post_destroyed.destroyed?
+          @status = "success"
+        else
+          @status = "fail"
+        end
+      end
+    end
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   </head>
 
   <body>
+    <%= render partial: "shared/flash" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/posts/_modal_post_container.html.erb
+++ b/app/views/posts/_modal_post_container.html.erb
@@ -1,0 +1,1 @@
+<div id="modal-post" class="modal" tabindex="-1" role="dialog"></div>

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -1,7 +1,7 @@
 <div class="modal-dialog" role="document">
   <div class="modal-content">
     <div class="modal-header">
-      <h5 class="modal-title">新規投稿</h5>
+      <h5 class="modal-title"><%= title %></h5>
       <button type="button" class="close" data-dismiss="modal" aria-label="Close">
         <span aria-hidden="true">&times;</span>
       </button>
@@ -10,7 +10,7 @@
       <div class="post-form">
         <%= form_with model: @post, class: "post-form__form" do |form| %>
           <div class="post-form__form__menu">
-            <%= form.submit "投稿" , class: "post-form__form__menu__submit btn btn-primary" %>
+            <%= form.submit button, class: "post-form__form__menu__submit btn btn-primary" %>
             <button type="button" class="post-form__form__menu__cancel btn btn-outline-primary" data-dismiss="modal">破棄</button>
           </div>
           <div class="post-form__form__content">

--- a/app/views/posts/_modal_post_new.html.erb
+++ b/app/views/posts/_modal_post_new.html.erb
@@ -1,0 +1,17 @@
+<div class="modal-dialog" role="document">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title">Modal title</h5>
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="modal-body">
+      <p>Modal body text goes here.</p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-primary">Save changes</button>
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/_modal_post_new.html.erb
+++ b/app/views/posts/_modal_post_new.html.erb
@@ -1,17 +1,27 @@
 <div class="modal-dialog" role="document">
   <div class="modal-content">
     <div class="modal-header">
-      <h5 class="modal-title">Modal title</h5>
+      <h5 class="modal-title">新規投稿</h5>
       <button type="button" class="close" data-dismiss="modal" aria-label="Close">
         <span aria-hidden="true">&times;</span>
       </button>
     </div>
     <div class="modal-body">
-      <p>Modal body text goes here.</p>
-    </div>
-    <div class="modal-footer">
-      <button type="button" class="btn btn-primary">Save changes</button>
-      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      <div class="post-form">
+        <%= form_with model: @post, class: "post-form__form" do |form| %>
+          <div class="post-form__form__menu">
+            <%= form.submit "投稿" , class: "post-form__form__menu__submit btn btn-primary" %>
+            <button type="button" class="post-form__form__menu__cancel btn btn-outline-primary" data-dismiss="modal">破棄</button>
+          </div>
+          <div class="post-form__form__content">
+            <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>
+            <%= form.label :image, class: "post-form__form__content__image" do%>
+              <%= icon("fas", "image") %>
+              <%= form.file_field :image, class: "post-form__form__content__image__field" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -1,5 +1,3 @@
-<div id="modal-post" class="modal" tabindex="-1" role="dialog"></div>
-
 <nav class="navbar navbar-expand-sm navbar-light bg-light">
   <%= link_to "Twitter Clone", root_path, class:"navbar-brand" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -1,3 +1,5 @@
+<div id="modal-post" class="modal" tabindex="-1" role="dialog"></div>
+
 <nav class="navbar navbar-expand-sm navbar-light bg-light">
   <%= link_to "Twitter Clone", root_path, class:"navbar-brand" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -7,7 +9,7 @@
     <ul class="navbar-nav">
       <% if user_signed_in? %>
         <li class="nav-item">
-          <%= link_to "投稿", new_post_path, class: "nav-link" %>
+          <%= link_to "投稿", new_post_path, remote: true, class: "nav-link" %>
         </li>
         <li class="nav-item">
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link" %>

--- a/app/views/posts/_post_form.html.erb
+++ b/app/views/posts/_post_form.html.erb
@@ -1,5 +1,5 @@
 <div class="post-form">
-  <%= form_with model: @post, class: "post-form__form" do |form| %>
+  <%= form_with model: @post, local: true, class: "post-form__form" do |form| %>
     <div class="post-form__form__menu">
       <%= form.submit submit_btn , class: "post-form__form__menu__submit btn btn-primary" %>
       <%= link_to "破棄", user_path(current_user.id) , class: "post-form__form__menu__cancel btn btn-outline-primary" %>

--- a/app/views/posts/_post_form.html.erb
+++ b/app/views/posts/_post_form.html.erb
@@ -1,0 +1,15 @@
+<div class="post-form">
+  <%= form_with model: @post, class: "post-form__form" do |form| %>
+    <div class="post-form__form__menu">
+      <%= form.submit submit_btn , class: "post-form__form__menu__submit btn btn-primary" %>
+      <div class="post-form__form__menu__cancel btn btn-outline-primary">破棄</div>
+    </div>
+    <div class="post-form__form__content">
+      <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>
+      <%= form.label :image, class: "post-form__form__content__image" do%>
+        <%= icon("fas", "image") %>
+        <%= form.file_field :image, class: "post-form__form__content__image__field" %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/posts/_post_form.html.erb
+++ b/app/views/posts/_post_form.html.erb
@@ -2,7 +2,7 @@
   <%= form_with model: @post, class: "post-form__form" do |form| %>
     <div class="post-form__form__menu">
       <%= form.submit submit_btn , class: "post-form__form__menu__submit btn btn-primary" %>
-      <div class="post-form__form__menu__cancel btn btn-outline-primary">破棄</div>
+      <%= link_to "破棄", user_path(current_user.id) , class: "post-form__form__menu__cancel btn btn-outline-primary" %>
     </div>
     <div class="post-form__form__content">
       <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>

--- a/app/views/posts/create.js.erb
+++ b/app/views/posts/create.js.erb
@@ -1,0 +1,6 @@
+<% if @status == 'success' %>
+$(".posts").prepend("<%= j(render("shared/post_card", post: @post_latest)) %>");
+<%  elsif @status == 'fail' %>
+alert('メッセージの投稿に失敗しました');
+<% end %>
+$("#modal-post").modal("hide");

--- a/app/views/posts/create.js.erb
+++ b/app/views/posts/create.js.erb
@@ -1,6 +1,6 @@
 <% if @status == 'success' %>
 $(".posts").prepend("<%= j(render("shared/post_card", post: @post_latest)) %>");
 <%  elsif @status == 'fail' %>
-alert('メッセージの投稿に失敗しました');
+alert('メッセージの投稿に失敗しました。メッセージを入力してください。');
 <% end %>
 $("#modal-post").modal("hide");

--- a/app/views/posts/destroy.js.erb
+++ b/app/views/posts/destroy.js.erb
@@ -1,0 +1,3 @@
+<% if @status == 'success' %>
+$(".posts__card[data-post-id='<%= @post_destroyed.id %>']").remove();
+<% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: "navbar" %>
+<%= render partial: "post_form", locals: {submit_btn: "更新"} %>
+

--- a/app/views/posts/edit.js.erb
+++ b/app/views/posts/edit.js.erb
@@ -1,2 +1,2 @@
-$("#modal-post").html("<%= escape_javascript(render 'modal_post_new') %>")
+$("#modal-post").html("<%= escape_javascript(render partial: 'modal_post_form', locals: { title: "投稿を編集", button: "更新" } ) %>")
 $("#modal-post").modal("show")

--- a/app/views/posts/edit.js.erb
+++ b/app/views/posts/edit.js.erb
@@ -1,0 +1,2 @@
+$("#modal-post").html("<%= escape_javascript(render 'modal_post_new') %>")
+$("#modal-post").modal("show")

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,5 @@
 <%= render "navbar" %>
+<%= render "modal_post_container" %>
 <div class="posts">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,17 +1,2 @@
-<%= render "navbar" %>
-
-<div class="post-form">
-  <%= form_with model: @post, class: "post-form__form" do |form| %>
-    <div class="post-form__form__menu">
-      <%= form.submit "投稿", class: "post-form__form__menu__submit btn btn-primary" %>
-      <div class="post-form__form__menu__cancel btn btn-outline-primary">破棄</div>
-    </div>
-    <div class="post-form__form__content">
-      <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>
-      <%= form.label :image, class: "post-form__form__content__image" do%>
-        <%= icon("fas", "image") %>
-        <%= form.file_field :image, class: "post-form__form__content__image__field" %>
-      <% end %>
-    </div>
-  <% end %>
-</div>
+<%= render partial: "navbar" %>
+<%= render partial: "post_form", locals: {submit_btn: "投稿"} %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -9,7 +9,7 @@
     <div class="post-form__form__content">
       <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>
       <%= form.label :image, class: "post-form__form__content__image" do%>
-        <%= icon("fas", "photo-video") %>
+        <%= icon("fas", "image") %>
         <%= form.file_field :image, class: "post-form__form__content__image__field" %>
       <% end %>
     </div>

--- a/app/views/posts/new.js.erb
+++ b/app/views/posts/new.js.erb
@@ -1,0 +1,2 @@
+$("#modal-post").html("<%= escape_javascript(render 'modal_post_new') %>")
+$("#modal-post").modal("show")

--- a/app/views/posts/new.js.erb
+++ b/app/views/posts/new.js.erb
@@ -1,2 +1,2 @@
-$("#modal-post").html("<%= escape_javascript(render 'modal_post_new') %>")
+$("#modal-post").html("<%= escape_javascript(render partial: 'modal_post_form', locals: { title: "新規投稿", button: "投稿" } ) %>")
 $("#modal-post").modal("show")

--- a/app/views/posts/update.js.erb
+++ b/app/views/posts/update.js.erb
@@ -1,0 +1,7 @@
+<% if @status == 'success' %>
+var current_post = $(".posts__card[data-post-id='<%= @post.id %>']");
+current_post.replaceWith("<%= j(render("shared/post_card", post: @post)) %>")
+<%  elsif @status == 'fail' %>
+alert('メッセージの投稿に失敗しました。メッセージを入力してください。');
+<% end %>
+$("#modal-post").modal("hide");

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <%= content_tag(:div, message, class: "flash flash__message--#{message_type}") %>
+<% end %>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -16,7 +16,7 @@
           <li class="dropdown-item">
             <%= link_to "削除", post, method: :delete, remote: true, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
           </li>
-          <li class="dropdown-item"> <%= link_to "編集", "#" %> </li>
+          <li class="dropdown-item"> <%= link_to "編集", edit_post_path(post.id) %> </li>
         </ul>
       </li>
 

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -8,11 +8,11 @@
         <%= post.updated_at %>
       </li>
 
-      <li class="dropdown">
-        <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+      <li class="posts__card__header__info__dropdown dropdown">
+        <button class="btn btn-outline-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
           <%= icon("fas", "cog") %>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="posts__card__header__info__dropdown__menu dropdown-menu">
           <li class="dropdown-item"> <%= link_to "削除", "#" %> </li>
           <li class="dropdown-item"> <%= link_to "編集", "#" %> </li>
         </ul>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -9,7 +9,7 @@
       </li>
 
       <li class="posts__card__header__info__dropdown dropdown">
-        <button class="btn btn-outline-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+        <button class="posts__card__header__info__dropdown__btn btn btn-outline-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
           <%= icon("fas", "cog") %>
         </button>
         <ul class="posts__card__header__info__dropdown__menu dropdown-menu">

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -13,7 +13,7 @@
           <%= icon("fas", "cog") %>
         </button>
         <ul class="posts__card__header__info__dropdown__menu dropdown-menu">
-          <li class="dropdown-item"> <%= link_to "削除", "#" %> </li>
+          <li class="dropdown-item"> <%= link_to "削除", post_path(post.id), method: :delete %> </li>
           <li class="dropdown-item"> <%= link_to "編集", "#" %> </li>
         </ul>
       </li>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -14,7 +14,7 @@
         </button>
         <ul class="posts__card__header__info__dropdown__menu dropdown-menu">
           <li class="dropdown-item">
-            <%= link_to "削除", post, method: :delete, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
+            <%= link_to "削除", post, method: :delete, remote: true, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
           </li>
           <li class="dropdown-item"> <%= link_to "編集", "#" %> </li>
         </ul>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -5,7 +5,7 @@
         <%= link_to post.user.name, user_path(post.user.id) %>
       </li>
       <li class="posts__card__header__info__date">
-        <%= post.updated_at %>
+        <%= post.updated_at.strftime("%Y/%m/%d(%a) %H:%M") %>
       </li>
       <% if user_signed_in? && current_user.id == post.user.id %>
         <li class="posts__card__header__info__dropdown dropdown">

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -7,6 +7,17 @@
       <li class="posts__card__header__info__date">
         <%= post.updated_at %>
       </li>
+
+      <li class="dropdown">
+        <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+          <%= icon("fas", "cog") %>
+        </button>
+        <ul class="dropdown-menu">
+          <li class="dropdown-item"> <%= link_to "削除", "#" %> </li>
+          <li class="dropdown-item"> <%= link_to "編集", "#" %> </li>
+        </ul>
+      </li>
+
     </ul>
   </div>
   <% if post.image.identifier %>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -7,19 +7,19 @@
       <li class="posts__card__header__info__date">
         <%= post.updated_at %>
       </li>
-
-      <li class="posts__card__header__info__dropdown dropdown">
-        <button class="posts__card__header__info__dropdown__btn btn btn-outline-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
-          <%= icon("fas", "cog") %>
-        </button>
-        <ul class="posts__card__header__info__dropdown__menu dropdown-menu">
-          <li class="dropdown-item">
-            <%= link_to "削除", post, method: :delete, remote: true, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
-          </li>
-          <li class="dropdown-item"> <%= link_to "編集", edit_post_path(post.id) %> </li>
-        </ul>
-      </li>
-
+      <% if user_signed_in? && current_user.id == post.user.id %>
+        <li class="posts__card__header__info__dropdown dropdown">
+          <button class="posts__card__header__info__dropdown__btn btn btn-outline-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+            <%= icon("fas", "cog") %>
+          </button>
+          <ul class="posts__card__header__info__dropdown__menu dropdown-menu">
+            <li class="dropdown-item">
+              <%= link_to "削除", post, method: :delete, remote: true, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
+            </li>
+            <li class="dropdown-item"> <%= link_to "編集", edit_post_path(post.id) %> </li>
+          </ul>
+        </li>
+      <% end %>
     </ul>
   </div>
   <% if post.image.identifier %>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -13,7 +13,9 @@
           <%= icon("fas", "cog") %>
         </button>
         <ul class="posts__card__header__info__dropdown__menu dropdown-menu">
-          <li class="dropdown-item"> <%= link_to "削除", post_path(post.id), method: :delete %> </li>
+          <li class="dropdown-item">
+            <%= link_to "削除", post, method: :delete, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
+          </li>
           <li class="dropdown-item"> <%= link_to "編集", "#" %> </li>
         </ul>
       </li>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -16,7 +16,7 @@
             <li class="dropdown-item">
               <%= link_to "削除", post, method: :delete, remote: true, title: "投稿を削除", data: { confirm: '削除してもよろしいですか?', commit: '削除', cancel: '中止' } %>
             </li>
-            <li class="dropdown-item"> <%= link_to "編集", edit_post_path(post.id) %> </li>
+            <li class="dropdown-item"> <%= link_to "編集", edit_post_path(post.id), remote: true %> </li>
           </ul>
         </li>
       <% end %>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -1,4 +1,4 @@
-<div class="posts__card card mx-auto">
+<div class="posts__card card mx-auto" data-post-id="<%= post.id %>">
   <div class="posts__card__header card-header">
     <ul class="posts__card__header__info">
       <li class="posts__card__header__info__username">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,6 @@
 <div class="header">
   <%= render "posts/navbar" %>
+  <%= render "posts/modal_post_container" %>
   <div class="header__user-info">
     <div class="header__user-info__inner">
       <div class="header__user-info__inner__user-name"><%= @user.name %></div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module TwitterClone
   class Application < Rails::Application
     config.autoload_paths += Dir[Rails.root.join('app', 'uploaders')]
+    config.time_zone = 'Asia/Tokyo'
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "posts#index"
   resources :users, only: [:show]
-  resources :posts, only: [:new, :create, :destroy]
+  resources :posts, only: [:new, :create, :destroy, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "posts#index"
   resources :users, only: [:show]
-  resources :posts, only: [:new, :create]
+  resources :posts, only: [:new, :create, :destroy]
 end


### PR DESCRIPTION
# what
- Bootstrapにより記事投稿・編集画面をモーダルウィンドウで表示するようにした。
- 投稿された記事にドロップダウンメニューを付け、削除・編集を選択できるようにした。
- メッセージ削除機能と編集機能を実装した。
- 'data-confirm-modal' gemにより、削除確認画面をモーダルウィンドウで表示するようにした。
- 記事の編集・削除メニューを投稿者にのみ表示するようにした。
- 記事の投稿・削除を非同期通信で行うようにした。
- 非同期通信の結果をJavaScriptでhtmlに反映させるようにした。

# why
- 記事の編集と削除がドロップダウンメニューで表示されることで見た目がシンプルになる。
- モーダルウィンドウで記事の投稿・編集・削除ができると、ページ遷移でユーザーを煩わせるを避けられる。
- 非同期通信でデータのやりとりをすることで、ページ読み込みによるユーザーストレスを低減できる。
# 実装内容を示す動画
- [キャプチャ動画 - c75a5a97c7b73eda92237b196738db01 - Gyazo](https://gyazo.com/c75a5a97c7b73eda92237b196738db01)