### PR TITLE
投稿のブックマーク機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ gem 'carrierwave'
 gem 'mini_magick'
 # 削除確認ダイアログをmodal表示
 gem 'data-confirm-modal'
+# ブックマークの数を数える
+gem 'counter_culture'
 
 group :development, :test do
   # 以下はvscodeの拡張用

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    after_commit_action (1.1.0)
+      activerecord (>= 3.0.0)
+      activesupport (>= 3.0.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -97,6 +100,10 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
+    counter_culture (2.2.4)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      after_commit_action (~> 1.0)
     crass (1.0.5)
     data-confirm-modal (1.6.2)
       railties (>= 3.0)
@@ -329,6 +336,7 @@ DEPENDENCIES
   carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
+  counter_culture
   data-confirm-modal
   debase
   debride

--- a/app/assets/stylesheets/module/_posts.scss
+++ b/app/assets/stylesheets/module/_posts.scss
@@ -35,5 +35,11 @@
       text-align: center;
       padding: 1rem;
     }
+    &__bottom {
+      display: flex;
+      &__bookmarks-count {
+        margin-left: 1rem;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/module/_users.scss
+++ b/app/assets/stylesheets/module/_users.scss
@@ -12,11 +12,18 @@
       justify-content: space-between;
       align-items: center;
       &__user-name {
+        a {
+          text-decoration: none;
+          color: black;
+        }
       }
       &__menu {
         margin: 0;
         padding: 0;
         &__bookmark {
+          &--highlight {
+            border-bottom: 1px solid blue;
+          }
           a {
             color: grey;
             text-decoration: none;

--- a/app/assets/stylesheets/module/_users.scss
+++ b/app/assets/stylesheets/module/_users.scss
@@ -16,6 +16,12 @@
       &__menu {
         margin: 0;
         padding: 0;
+        &__bookmark {
+          a {
+            color: grey;
+            text-decoration: none;
+          }
+        }
       }
     }
   }

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,0 +1,2 @@
+class BookmarksController < ApplicationController
+end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,2 +1,7 @@
 class BookmarksController < ApplicationController
+  def create
+  end
+
+  def destroy
+  end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,4 +1,6 @@
 class BookmarksController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     bookmark = Bookmark.create(post_id: params[:post_id], user_id: current_user.id)
     if bookmark.errors.empty?

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -12,5 +12,7 @@ class BookmarksController < ApplicationController
   end
 
   def destroy
+    current_user.bookmarks.find_by(post_id: params[:post_id]).destroy
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -13,7 +13,14 @@ class BookmarksController < ApplicationController
   end
 
   def destroy
-    current_user.bookmarks.find_by(post_id: params[:post_id]).destroy
-    redirect_back(fallback_location: root_path)
+    bookmark = current_user.bookmarks.find_by(post_id: params[:post_id])
+    if bookmark
+      bookmark.destroy
+      redirect_back(fallback_location: root_path)
+    end
+  end
+
+  def bookmark_params
+    params.permit(:post_id).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -2,7 +2,8 @@ class BookmarksController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    bookmark = Bookmark.create(post_id: params[:post_id], user_id: current_user.id)
+    return if Bookmark.find_by(bookmark_params)
+    bookmark = Bookmark.create(bookmark_params)
     if bookmark.errors.empty?
       flash[:notice] = "ブックマークしました"
     else

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,11 @@
 class BookmarksController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @user = User.find(params[:user_id])
+    @posts = @user.favposts.order(created_at: :desc)
+  end
+
   def create
     return if Bookmark.find_by(bookmark_params)
     bookmark = Bookmark.create(bookmark_params)

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,5 +1,12 @@
 class BookmarksController < ApplicationController
   def create
+    bookmark = Bookmark.create(post_id: params[:post_id], user_id: current_user.id)
+    if bookmark.errors.empty?
+      flash[:notice] = "ブックマークしました"
+    else
+      flash[:alert] = "ブックマークに失敗しました"
+    end
+    redirect_back(fallback_location: root_path)
   end
 
   def destroy

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,0 +1,2 @@
+class Bookmark < ApplicationRecord
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,2 +1,4 @@
 class Bookmark < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,4 +1,5 @@
 class Bookmark < ApplicationRecord
+  validates :user_id, uniqueness: { scope: :post_id }
   belongs_to :user
   belongs_to :post
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -2,4 +2,5 @@ class Bookmark < ApplicationRecord
   validates :user_id, uniqueness: { scope: :post_id }
   belongs_to :user
   belongs_to :post
+  counter_culture :post
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,4 +2,5 @@ class Post < ApplicationRecord
   mount_uploader :image, PictureUploader
   validates :content, presence: true, unless: :image?
   belongs_to :user
+  has_many :bookmarks
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,4 +4,8 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :bookmarks, dependent: :destroy
   has_many :favusers, through: :bookmarks, source: :user
+
+  def is_bookmarked(user_id)
+    favuser_ids.include?(user_id)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,5 @@ class Post < ApplicationRecord
   validates :content, presence: true, unless: :image?
   belongs_to :user
   has_many :bookmarks
+  has_many :favusers, through: :bookmarks, source: :user
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,6 @@ class Post < ApplicationRecord
   mount_uploader :image, PictureUploader
   validates :content, presence: true, unless: :image?
   belongs_to :user
-  has_many :bookmarks
+  has_many :bookmarks, dependent: :destroy
   has_many :favusers, through: :bookmarks, source: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   has_many :posts
+  has_many :bookmarks
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   has_many :posts
-  has_many :bookmarks
+  has_many :bookmarks, dependent: :destroy
   has_many :favposts, through: :bookmarks, source: :post
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   has_many :posts
   has_many :bookmarks
+  has_many :favposts, through: :bookmarks, source: :post
 end

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,0 +1,22 @@
+<div class="header">
+  <%= render "posts/navbar" %>
+  <%= render "posts/modal_post_container" %>
+  <div class="header__user-info">
+    <div class="header__user-info__inner">
+      <div class="header__user-info__inner__user-name">
+        <%= link_to @user.name, user_path(@user.id) %>
+      </div>
+      <ul class="header__user-info__inner__menu">
+        <li class="header__user-info__inner__menu__bookmark">
+          <%= link_to user_bookmarks_path(@user.id), class: "header__user-info__inner__menu__bookmark--highlight" do %>
+            いいね： <%= @user.bookmarks.count %>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="posts">
+  <%= render partial: "shared/post_card", collection: @posts, as: :post %>
+</div>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -35,6 +35,14 @@
     </div>
   <% end %>
   <div class="posts__card__bottom card-body">
-    <%= link_to icon("far", "heart"), post_bookmarks_path(post.id), method: :create, class: "posts__card__bottom__bookmark" %>
+    <% if user_signed_in? %>
+      <% if post.is_bookmarked(current_user.id) %>
+        <%= link_to icon("fas", "heart"), post_bookmark_path(post.id, post.bookmarks.find_by(user_id: current_user.id).id), method: :delete, class: "posts__card__bottom__bookmark" %>
+      <% else %>
+        <%= link_to icon("far", "heart"), post_bookmarks_path(post.id), method: :create, class: "posts__card__bottom__bookmark" %>
+      <% end %>
+    <% else %>
+      <%= link_to link_to icon("far", "heart"), new_user_session_path %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -44,5 +44,6 @@
     <% else %>
       <%= link_to link_to icon("far", "heart"), new_user_session_path, class: "posts__card__bottom__bookmark" %>
     <% end %>
+    <div class="posts__card__bottom__bookmarks-count"><%= post.bookmarks_count %></div>
   </div>
 </div>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -35,6 +35,6 @@
     </div>
   <% end %>
   <div class="posts__card__bottom card-body">
-    <%= link_to icon("far", "heart"), "#", class: "posts__card__bottom__bookmark" %>
+    <%= link_to icon("far", "heart"), post_bookmarks_path(post.id), method: :create, class: "posts__card__bottom__bookmark" %>
   </div>
 </div>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -35,15 +35,17 @@
     </div>
   <% end %>
   <div class="posts__card__bottom card-body">
-    <% if user_signed_in? %>
-      <% if post.is_bookmarked(current_user.id) %>
-        <%= link_to icon("fas", "heart"), post_bookmark_path(post.id, post.bookmarks.find_by(user_id: current_user.id).id), method: :delete, class: "posts__card__bottom__bookmark" %>
+    <div class="posts__card__bottom__bookmark">
+      <% if user_signed_in? %>
+        <% if post.is_bookmarked(current_user.id) %>
+          <%= link_to icon("fas", "heart"), post_bookmark_path(post.id, post.bookmarks.find_by(user_id: current_user.id).id), method: :delete %>
+        <% else %>
+          <%= link_to icon("far", "heart"), post_bookmarks_path(post.id), method: :create %>
+        <% end %>
       <% else %>
-        <%= link_to icon("far", "heart"), post_bookmarks_path(post.id), method: :create, class: "posts__card__bottom__bookmark" %>
+        <%= link_to link_to icon("far", "heart"), new_user_session_path %>
       <% end %>
-    <% else %>
-      <%= link_to link_to icon("far", "heart"), new_user_session_path, class: "posts__card__bottom__bookmark" %>
-    <% end %>
+    </div>
     <div class="posts__card__bottom__bookmarks-count"><%= post.bookmarks_count %></div>
   </div>
 </div>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -34,8 +34,7 @@
       </div>
     </div>
   <% end %>
-  <div class="card-body">
-    <a href="#" class="card-link">Card link</a>
-    <a href="#" class="card-link">Another link</a>
+  <div class="posts__card__bottom card-body">
+    <%= link_to icon("far", "heart"), "#", class: "posts__card__bottom__bookmark" %>
   </div>
 </div>

--- a/app/views/shared/_post_card.html.erb
+++ b/app/views/shared/_post_card.html.erb
@@ -42,7 +42,7 @@
         <%= link_to icon("far", "heart"), post_bookmarks_path(post.id), method: :create, class: "posts__card__bottom__bookmark" %>
       <% end %>
     <% else %>
-      <%= link_to link_to icon("far", "heart"), new_user_session_path %>
+      <%= link_to link_to icon("far", "heart"), new_user_session_path, class: "posts__card__bottom__bookmark" %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
       <div class="header__user-info__inner__user-name"><%= @user.name %></div>
       <ul class="header__user-info__inner__menu">
         <li class="header__user-info__inner__menu__bookmark">
-          <%= link_to "#" do %>
+          <%= link_to user_bookmarks_path(@user.id) do %>
             いいね： <%= @user.bookmarks.count %>
           <% end %>
         </li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,11 @@
     <div class="header__user-info__inner">
       <div class="header__user-info__inner__user-name"><%= @user.name %></div>
       <ul class="header__user-info__inner__menu">
-        <li class="header__user-info__inner__menu__bookmark">いいね： 10</li>
+        <li class="header__user-info__inner__menu__bookmark">
+          <%= link_to "#" do %>
+            いいね： <%= @user.bookmarks.count %>
+          <% end %>
+        </li>
       </ul>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "posts#index"
-  resources :users, only: [:show]
+  resources :users, only: [:show] do
+    resources :bookmarks, only: [:index]
+  end
   resources :posts, only: [:new, :create, :destroy, :edit, :update] do
     resources :bookmarks, only: [:create, :destroy]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "posts#index"
   resources :users, only: [:show]
-  resources :posts, only: [:new, :create, :destroy, :edit, :update]
+  resources :posts, only: [:new, :create, :destroy, :edit, :update] do
+    resources :bookmarks, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20191115114756_create_bookmarks.rb
+++ b/db/migrate/20191115114756_create_bookmarks.rb
@@ -1,0 +1,8 @@
+class CreateBookmarks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bookmarks do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191115114756_create_bookmarks.rb
+++ b/db/migrate/20191115114756_create_bookmarks.rb
@@ -1,7 +1,8 @@
 class CreateBookmarks < ActiveRecord::Migration[5.2]
   def change
     create_table :bookmarks do |t|
-
+      t.references :user, foreign_key: true
+      t.references :post, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20191115114756_create_bookmarks.rb
+++ b/db/migrate/20191115114756_create_bookmarks.rb
@@ -4,6 +4,8 @@ class CreateBookmarks < ActiveRecord::Migration[5.2]
       t.references :user, foreign_key: true
       t.references :post, foreign_key: true
       t.timestamps
+
+      t.index [:user_id, :post_id], unique: true
     end
   end
 end

--- a/db/migrate/20191117092617_add_bookmarks_count_to_posts.rb
+++ b/db/migrate/20191117092617_add_bookmarks_count_to_posts.rb
@@ -1,0 +1,9 @@
+class AddBookmarksCountToPosts < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :posts, :bookmarks_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :posts, :bookmarks_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_13_073309) do
+ActiveRecord::Schema.define(version: 2019_11_15_114756) do
+
+  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_bookmarks_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -35,5 +45,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_073309) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_15_114756) do
-
-  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "post_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["post_id"], name: "index_bookmarks_on_post_id"
-    t.index ["user_id"], name: "index_bookmarks_on_user_id"
-  end
+ActiveRecord::Schema.define(version: 2019_11_13_073309) do
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -44,7 +35,5 @@ ActiveRecord::Schema.define(version: 2019_11_15_114756) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "bookmarks", "posts"
-  add_foreign_key "bookmarks", "users"
   add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_13_073309) do
+ActiveRecord::Schema.define(version: 2019_11_15_114756) do
+
+  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -35,5 +44,7 @@ ActiveRecord::Schema.define(version: 2019_11_13_073309) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
   add_foreign_key "posts", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_15_114756) do
+ActiveRecord::Schema.define(version: 2019_11_17_092617) do
 
   create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2019_11_15_114756) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "bookmarks_count", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
# what
- 投稿したメッセージに対してブックマークをつける機能を実装した
- bookmarksテーブルをpostとusersの中間テーブルとして作成した
- bookmarksのカラムのうち、post_idとuser_idを複合キーのインデックスに指定し、ブックマークが重複登録されるのを回避した。
- modelのバリデーションでもブックマークの重複を抑止した。
- bookmarkを作成する際にpost.idを取得するため、bookmarkへのルーティングはpostsにネストさせた
- bookmarksコントローラーには、createとdestroyアクションを付け、それぞれブックマークの作成と削除ができるようにした
- bookmarks#createとdestroyへのリンクを各postのビューに表示した
- userがすでにブックマークしているかどうかに応じてブックマークアイコンを切り替えるようにした
- gem 'counter_culture'を用いて、ブックマークのカウントデータを更新するようにした。
- ブックマークのカウントをメッセージに表示した。
- ブックマークリスト表示するビューを作成した
# why
- twitterのクローンアプリとして、ブックマーク機能は重要な機能だから。
- メッセージアプリでブックマーク機能がないと、利便性が大きく損なわれる。
