### PR TITLE
トップページのタイムラインで自分とフォロー先の投稿のみを表示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ doc/
 
 # 投稿した画像を無視
 public/uploads/*
+
+# seedファイルのうち、temp_*のものはgithubにあげない
+db/seeds/temp_*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,11 @@ end
 gem 'fog-aws'
 
 group :development, :test do
+  # テスト用のemailアドレスを生成するため
+  gem 'faker'
+end
+
+group :development, :test do
   # 以下はvscodeの拡張用
   gem "rubocop"
   gem "ruby-debug-ide"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
     erubi (1.9.0)
     excon (0.71.1)
     execjs (2.7.0)
+    faker (2.7.0)
+      i18n (>= 1.6, < 1.8)
     faster (0.0.1)
     fastri (0.3.1.1)
     ffi (1.11.2)
@@ -382,6 +384,7 @@ DEPENDENCIES
   debase
   debride
   devise
+  faker
   faster
   fastri
   fog-aws

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,12 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:edit, :update]
 
   def index
-    @posts = Post.all.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+    timeline = Post.timeline(current_user)
+    @posts = if timeline
+               timeline.order(created_at: :desc).page(params[:page]).per(10)
+             else
+               Kaminari.paginate_array([]).page(1)
+             end
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,7 @@ class PostsController < ApplicationController
   def index
     timeline = Post.timeline(current_user)
     @posts = if timeline
-               timeline.order(created_at: :desc).page(params[:page]).per(10)
+               timeline.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
              else
                Kaminari.paginate_array([]).page(1)
              end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -17,8 +17,10 @@ class RelationshipsController < ApplicationController
 
     if relationship && relationship.destroy
       flash[:notice] = "フォローを外しました"
-      redirect_back(fallback_location: root_path)
+    else
+      flash[:alert] = "フォローを外せませんでした。"
     end
+    redirect_back(fallback_location: root_path)
   end
 
   def relationship_params

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -13,9 +13,10 @@ class RelationshipsController < ApplicationController
   end
 
   def destroy
-    relationship = current_user.relationships.find_by(user_id: params[:user_id])
-    if relationship
-      relationship.destroy
+    relationship = current_user.reverse_relationships.find_by(user_id: params[:user_id])
+
+    if relationship && relationship.destroy
+      flash[:notice] = "フォローを外しました"
       redirect_back(fallback_location: root_path)
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,7 +11,7 @@ class Post < ApplicationRecord
 
   def self.timeline(user)
     if user
-      Post.where(id: [user.id] + user.following_ids)
+      Post.where(user_id: [user.id] + user.following_ids)
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,4 +8,10 @@ class Post < ApplicationRecord
   def is_bookmarked(user_id)
     favuser_ids.include?(user_id)
   end
+
+  def self.timeline(user)
+    if user
+      Post.where(id: [user.id] + user.following_ids)
+    end
+  end
 end

--- a/app/views/shared/_mypage_menubar.html.erb
+++ b/app/views/shared/_mypage_menubar.html.erb
@@ -18,7 +18,7 @@
         <li class="header__user-info__inner__menu__item">
           <% if user_signed_in? %>
             <% if @user.is_followed(current_user) %>
-              <%= link_to "フォローを外す", user_relationship_path(@user.id, @user.relationships.find_by(fan_id: current_user.id).id), method: :delete, class: "header__user-info__inner__menu__follow btn btn-info" %>
+              <%= link_to "フォローを外す", user_relationship_path(@user.id), method: :delete, class: "header__user-info__inner__menu__follow btn btn-info" %>
             <% else %>
               <%= link_to "フォロー", user_relationships_path(@user.id), method: :create, class: "header__user-info__inner__menu__follow btn btn-outline-info" %>
             <% end %>

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,0 +1,21 @@
+# seedsファイルの分割適用のためのタスク。
+# db/seeds.rbにseedsデータをすべてまとめず分割して適用するときに使う。
+
+# db/seeds直下にseedsファイルを配置しておく。
+# db/seeds/*.rbのすべてのseedsファイルを読み込んでタスク化する。
+# 例えば、db/seeds/user.rbを実行する場合にはrake db:seed:userとターミナルで打つ。
+Dir.glob(File.join(Rails.root, 'db', 'seeds', '*.rb')).each do |file|
+  desc "Load the seed data from db/seeds/#{File.basename(file)}."
+  task "db:seed:#{File.basename(file).gsub(/\..+$/, '')}": :environment do
+    load(file)
+  end
+end
+
+# db/seeds/*.rbのすべてのseedsファイルを実行する。
+# db:seed:allとターミナルで打つ。
+desc "Load all the seed data from db/seeds directory"
+task "db:seed:all": :environment do
+  Dir.glob(File.join(Rails.root, 'db', 'seeds', '*.rb')).each do |file|
+    load(file)
+  end
+end


### PR DESCRIPTION
# what
- トップページで自分の投稿とフォローしている人の投稿を表示する。
- フォロー機能のバグを修正して適切にフォロー解除できるようにした
- kaminariのページネーションで投稿が0件のときに対応できるようにした。
- seedファイルを用途ごとに分割して適用できるタスクファイルを追加した

# why
- この実装までは全ての投稿を表示していたが、利用者の興味のない投稿を表示するのは不便なので、仕様を変更した。
- ページネーションで投稿数が0のときにエラーが出ていたのを解消するため.
- seedで初期データを生成する際に、userやpostsのみを生成したい場合もあるため。
