### PR TITLE
フォローを非同期で行う機能の実装

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -11,12 +11,24 @@ class RelationshipsController < ApplicationController
   def create
     return if Relationship.find_by(relationship_params)
     relationship = Relationship.create(relationship_params)
-    if relationship.errors.empty?
-      flash[:notice] = "フォローしました"
-    else
-      flash[:alert] = "フォローに失敗しました"
+
+    respond_to do |format|
+      format.html do
+        if relationship.errors.empty?
+          flash[:notice] = "フォローしました"
+        else
+          flash[:alert] = "フォローに失敗しました"
+        end
+        redirect_back(fallback_location: root_path)
+      end
+      format.js do
+        if relationship.errors.empty?
+          @status = "success"
+        else
+          @status = "fail"
+        end
+      end
     end
-    redirect_back(fallback_location: root_path)
   end
 
   def destroy

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -9,8 +9,9 @@ class RelationshipsController < ApplicationController
   end
 
   def create
-    return if Relationship.find_by(relationship_params)
-    relationship = Relationship.create(relationship_params)
+    @user = User.find_by(id: relationship_params[:user_id])
+    redirect_back(fallback_location: root_path) and return unless @user
+    relationship = current_user.follow(@user)
 
     respond_to do |format|
       format.html do
@@ -32,9 +33,11 @@ class RelationshipsController < ApplicationController
   end
 
   def destroy
-    relationship = current_user.reverse_relationships.find_by(user_id: params[:user_id])
+    @user = User.find_by(id: relationship_params[:user_id])
+    redirect_back(fallback_location: root_path) and return unless @user
+    relationship = current_user.unfollow(@user)
 
-    if relationship && relationship.destroy
+    if relationship
       flash[:notice] = "フォローを外しました"
     else
       flash[:alert] = "フォローを外せませんでした。"

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,6 +1,7 @@
 class RelationshipsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_user, only: [:followers, :followings]
+  before_action :set_user, only: [:create, :destroy, :followers, :followings]
+  before_action :redirect_if_user_nil, only: [:create, :destroy]
 
   def followers
   end
@@ -9,8 +10,6 @@ class RelationshipsController < ApplicationController
   end
 
   def create
-    @user = User.find_by(id: relationship_params[:user_id])
-    redirect_back(fallback_location: root_path) and return unless @user
     relationship = current_user.follow(@user)
 
     respond_to do |format|
@@ -33,8 +32,6 @@ class RelationshipsController < ApplicationController
   end
 
   def destroy
-    @user = User.find_by(id: relationship_params[:user_id])
-    redirect_back(fallback_location: root_path) and return unless @user
     relationship = current_user.unfollow(@user)
 
     if relationship
@@ -47,11 +44,11 @@ class RelationshipsController < ApplicationController
 
   private
 
-  def relationship_params
-    params.permit(:user_id).merge(fan_id: current_user.id)
-  end
-
   def set_user
     @user = User.find(params[:user_id])
+  end
+
+  def redirect_if_user_nil
+    redirect_back(fallback_location: root_path) and return unless @user
   end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -33,13 +33,23 @@ class RelationshipsController < ApplicationController
 
   def destroy
     relationship = current_user.unfollow(@user)
-
-    if relationship
-      flash[:notice] = "フォローを外しました"
-    else
-      flash[:alert] = "フォローを外せませんでした。"
+    respond_to do |format|
+      format.html do
+        if relationship
+          flash[:notice] = "フォローを外しました"
+        else
+          flash[:alert] = "フォローを外せませんでした。"
+        end
+        redirect_back(fallback_location: root_path)
+      end
+      format.js do
+        if relationship
+          @status = "success"
+        else
+          @status = "fail"
+        end
+      end
     end
-    redirect_back(fallback_location: root_path)
   end
 
   private

--- a/app/views/relationships/_follower_card.html.erb
+++ b/app/views/relationships/_follower_card.html.erb
@@ -1,4 +1,4 @@
-<div class="posts__card card mx-auto">
+<div class="posts__card card mx-auto" data-user-id="<%= user.id %>">
   <div class="card-body">
     <h5 class="card-title"><%= link_to user.name, user_path(user.id) %></h5>
     <% if current_user !=  user %>

--- a/app/views/relationships/_follower_list.html.erb
+++ b/app/views/relationships/_follower_list.html.erb
@@ -2,11 +2,7 @@
   <div class="card-body">
     <h5 class="card-title"><%= link_to user.name, user_path(user.id) %></h5>
     <% if current_user !=  user %>
-      <% if user.is_followed(current_user) %>
-        <%= link_to "フォローを外す", user_relationships_path(user.id), method: :delete, class: "btn btn-info" %>
-      <% else %>
-        <%= link_to "フォロー", user_relationships_path(user.id), method: :create, class: "btn btn-outline-info" %>
-      <% end %>
+      <%= render partial: "shared/follow_button", locals: { follower: current_user, followee: user } %>
     <% end %>
   </div>
 </div>

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,6 +1,8 @@
 <% if @status == 'success' %>
 var current_post = $(".posts__card[data-user-id='<%= @user.id %>']");
 current_post.replaceWith("<%= j(render("follower_card", user: @user)) %>");
+var navbar_follow_button = $("[data-user-id='<%= @user.id %>'][data-follow-button='true']");
+navbar_follow_button.html("<%= j(render("shared/follow_button", follower: current_user, followee: @user)) %>");
 <%  elsif @status == 'fail' %>
 alert("送信に失敗しました");
 <% end %>

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,6 @@
+<% if @status == 'success' %>
+var current_post = $(".posts__card[data-user-id='<%= @user.id %>']");
+current_post.replaceWith("<%= j(render("follower_card", user: @user)) %>");
+<%  elsif @status == 'fail' %>
+alert("送信に失敗しました");
+<% end %>

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,0 +1,8 @@
+<% if @status == 'success' %>
+var current_post = $(".posts__card[data-user-id='<%= @user.id %>']");
+current_post.replaceWith("<%= j(render("follower_card", user: @user)) %>");
+var navbar_follow_button = $("[data-user-id='<%= @user.id %>'][data-follow-button='true']");
+navbar_follow_button.html("<%= j(render("shared/follow_button", follower: current_user, followee: @user)) %>");
+<%  elsif @status == 'fail' %>
+alert("送信に失敗しました");
+<% end %>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "shared/mypage_menubar" %>
 
 <div class="posts">
-  <%= render partial: "follower_list", collection: @user.followers, as: :user %>
+  <%= render partial: "follower_card", collection: @user.followers, as: :user %>
 </div>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "shared/mypage_menubar" %>
 
 <div class="posts">
-  <%= render partial: "follower_list", collection: @user.followings, as: :user %>
+  <%= render partial: "follower_card", collection: @user.followings, as: :user %>
 </div>

--- a/app/views/shared/_follow_button.html.erb
+++ b/app/views/shared/_follow_button.html.erb
@@ -1,5 +1,5 @@
 <% if followee.is_followed(follower) %>
-  <%= link_to "フォローを外す", user_relationships_path(followee.id), method: :delete, class: "header__user-info__inner__menu__follow btn btn-info" %>
+  <%= link_to "フォローを外す", user_relationships_path(followee.id), method: :delete, remote: true, class: "header__user-info__inner__menu__follow btn btn-info" %>
 <% else %>
   <%= link_to "フォロー", user_relationships_path(followee.id), method: :post, remote: true, class: "header__user-info__inner__menu__follow btn btn-outline-info" %>
 <% end %>

--- a/app/views/shared/_follow_button.html.erb
+++ b/app/views/shared/_follow_button.html.erb
@@ -1,5 +1,5 @@
 <% if followee.is_followed(follower) %>
   <%= link_to "フォローを外す", user_relationships_path(followee.id), method: :delete, class: "header__user-info__inner__menu__follow btn btn-info" %>
 <% else %>
-  <%= link_to "フォロー", user_relationships_path(followee.id), method: :create, class: "header__user-info__inner__menu__follow btn btn-outline-info" %>
+  <%= link_to "フォロー", user_relationships_path(followee.id), method: :post, remote: true, class: "header__user-info__inner__menu__follow btn btn-outline-info" %>
 <% end %>

--- a/app/views/shared/_follow_button.html.erb
+++ b/app/views/shared/_follow_button.html.erb
@@ -1,0 +1,5 @@
+<% if followee.is_followed(follower) %>
+  <%= link_to "フォローを外す", user_relationships_path(followee.id), method: :delete, class: "header__user-info__inner__menu__follow btn btn-info" %>
+<% else %>
+  <%= link_to "フォロー", user_relationships_path(followee.id), method: :create, class: "header__user-info__inner__menu__follow btn btn-outline-info" %>
+<% end %>

--- a/app/views/shared/_mypage_menubar.html.erb
+++ b/app/views/shared/_mypage_menubar.html.erb
@@ -22,7 +22,7 @@
             フォロー: <%= @user.followings.count %>
           <% end %>
         </li>
-        <li class="header__user-info__inner__menu__item">
+        <li class="header__user-info__inner__menu__item" data-follow-button="true", data-user-id="<%= @user.id %>">
           <% if user_signed_in? && current_user != @user %>
             <%= render partial: "shared/follow_button", locals: { follower: current_user, followee: @user } %>
           <% end %>

--- a/app/views/shared/_mypage_menubar.html.erb
+++ b/app/views/shared/_mypage_menubar.html.erb
@@ -24,11 +24,7 @@
         </li>
         <li class="header__user-info__inner__menu__item">
           <% if user_signed_in? && current_user != @user %>
-            <% if @user.is_followed(current_user) %>
-              <%= link_to "フォローを外す", user_relationships_path(@user.id), method: :delete, class: "header__user-info__inner__menu__follow btn btn-info" %>
-            <% else %>
-              <%= link_to "フォロー", user_relationships_path(@user.id), method: :create, class: "header__user-info__inner__menu__follow btn btn-outline-info" %>
-            <% end %>
+            <%= render partial: "shared/follow_button", locals: { follower: current_user, followee: @user } %>
           <% end %>
         </li>
       </ul>


### PR DESCRIPTION
# what
- 非同期通信でフォローできるようにした
- フォロワーリストでフォローボタンを押すときの更新を非同期通信でできるようにした
- ヘッダーのフォローボタンを押したときの更新も非同期通信にした

# why
- フォローする度にリロードするのは、ユーザーの利便性を損なうから