### PR TITLE
投稿の検索機能の実装

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,0 +1,8 @@
+$(function() {
+  $("#search-posts").on("submit", function() {
+    var input = $(this).find("input[type='text']");
+    if (input.val().trim().length == 0) {
+      return false;
+    }
+  });
+});

--- a/app/assets/stylesheets/module/_posts.scss
+++ b/app/assets/stylesheets/module/_posts.scss
@@ -1,8 +1,14 @@
 .posts {
   padding-top: 1rem;
-  &__card {
+  %__card {
     max-width: 32rem;
     margin-bottom: 0.5rem;
+  }
+  &__card {
+    @extend %__card;
+    &--no-results {
+      @extend %__card;
+    }
     &__header {
       ul {
         margin: 0;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -75,9 +75,10 @@ class PostsController < ApplicationController
   end
 
   def search
-    posts = Post.search_by_content(params[:keyword])
-    @posts = pagenate(posts)
     @keyword = params[:keyword]
+    redirect_back(fallback_location: root_path) unless @keyword
+    posts = Post.search_by_content(@keyword)
+    @posts = pagenate(posts)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,6 +77,7 @@ class PostsController < ApplicationController
   def search
     posts = Post.search_by_content(params[:keyword])
     @posts = pagenate(posts)
+    @keyword = params[:keyword]
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -78,6 +78,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def search
+    @posts = Post.search_by_content(params[:keyword]).includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+  end
+
   private
 
   def set_new_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,11 +4,7 @@ class PostsController < ApplicationController
 
   def index
     timeline = Post.timeline(current_user)
-    @posts = if timeline
-               timeline.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
-             else
-               Kaminari.paginate_array([]).page(1)
-             end
+    @posts = pagenate(timeline)
   end
 
   def new
@@ -79,7 +75,8 @@ class PostsController < ApplicationController
   end
 
   def search
-    @posts = Post.search_by_content(params[:keyword]).includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+    posts = Post.search_by_content(params[:keyword])
+    @posts = pagenate(posts)
   end
 
   private
@@ -94,5 +91,13 @@ class PostsController < ApplicationController
 
   def post_params
     params.require(:post).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def pagenate(posts)
+    if posts
+      posts.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+    else
+      Kaminari.paginate_array([]).page(1)
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,4 +14,9 @@ class Post < ApplicationRecord
       Post.where(user_id: [user.id] + user.following_ids)
     end
   end
+
+  def self.search_by_content(keyword)
+    return if keyword.size == 0
+    Post.where("content like ?", "%#{keyword}%")
+  end
 end

--- a/app/views/bookmarks/create.js.erb
+++ b/app/views/bookmarks/create.js.erb
@@ -3,5 +3,5 @@ var current_post = $(".posts__card[data-post-id='<%= @post.id %>']");
 var target_bookmark = current_post.find(".posts__card__bottom");
 target_bookmark.replaceWith("<%= j(render("shared/post_card_bottom", post: @post)) %>");
 <%  elsif @status == 'fail' %>
-alert('メッセージの投稿に失敗しました。メッセージを入力してください。');
+alert('送信に失敗しました');
 <% end %>

--- a/app/views/bookmarks/destroy.js.erb
+++ b/app/views/bookmarks/destroy.js.erb
@@ -3,5 +3,5 @@ var current_post = $(".posts__card[data-post-id='<%= @post.id %>']");
 var target_bookmark = current_post.find(".posts__card__bottom");
 target_bookmark.replaceWith("<%= j(render("shared/post_card_bottom", post: @post)) %>");
 <%  elsif @status == 'fail' %>
-alert('メッセージの投稿に失敗しました。メッセージを入力してください。');
+alert('送信に失敗しました');
 <% end %>

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </ul>
     <%= form_with(url: search_posts_path, local: true, method: :get, class: "form-inline my-2 my-lg-0") do |form| %>
-      <%= form.text_field :keyword, value: params[:keyword], placeholder: "キーワード検索", class: "form-control mr-sm-2" %>
+      <%= form.text_field :keyword, value: @keyword, placeholder: "キーワード検索", class: "form-control mr-sm-2" %>
       <%= form.submit "検索", class: "btn btn-outline-success my-2 my-sm-0" %>
     <% end %>
   </div>

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -23,7 +23,7 @@
         </li>
       <% end %>
     </ul>
-    <%= form_with(url: search_posts_path, local: true, method: :get, class: "form-inline my-2 my-lg-0") do |form| %>
+    <%= form_with(url: search_posts_path, local: true, method: :get, id: "search-posts", class: "form-inline my-2 my-lg-0") do |form| %>
       <%= form.text_field :keyword, value: @keyword, placeholder: "キーワード検索", class: "form-control mr-sm-2" %>
       <%= form.submit "検索", class: "btn btn-outline-success my-2 my-sm-0" %>
     <% end %>

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -23,9 +23,9 @@
         </li>
       <% end %>
     </ul>
-    <form class="form-inline my-2 my-lg-0">
-      <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
-      <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
-    </form>
+    <%= form_with(url: search_posts_path, local: true, method: :get, class: "form-inline my-2 my-lg-0") do |form| %>
+      <%= form.text_field :keyword, placeholder: "キーワード検索", class: "form-control mr-sm-2" %>
+      <%= form.submit "検索", class: "btn btn-outline-success my-2 my-sm-0" %>
+    <% end %>
   </div>
 </nav>

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </ul>
     <%= form_with(url: search_posts_path, local: true, method: :get, class: "form-inline my-2 my-lg-0") do |form| %>
-      <%= form.text_field :keyword, placeholder: "キーワード検索", class: "form-control mr-sm-2" %>
+      <%= form.text_field :keyword, value: params[:keyword], placeholder: "キーワード検索", class: "form-control mr-sm-2" %>
       <%= form.submit "検索", class: "btn btn-outline-success my-2 my-sm-0" %>
     <% end %>
   </div>

--- a/app/views/posts/_notice_no_results.html.erb
+++ b/app/views/posts/_notice_no_results.html.erb
@@ -1,0 +1,3 @@
+<div class="posts__card--no-results mx-auto">
+  <h4><%= "#{@keyword}" %>の検索結果がありません</h4>
+</div>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,0 +1,6 @@
+<%= render "navbar" %>
+<%= render "modal_post_container" %>
+<div class="posts">
+  <%= render partial: "shared/post_card", collection: @posts, as: :post %>
+</div>
+<%= paginate(@posts) %>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -2,5 +2,6 @@
 <%= render "modal_post_container" %>
 <div class="posts">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
+  <%= render partial: "notice_no_results" %>
 </div>
 <%= paginate(@posts) %>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -2,6 +2,8 @@
 <%= render "modal_post_container" %>
 <div class="posts">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
-  <%= render partial: "notice_no_results" %>
+  <% if @posts.empty? %>
+    <%= render partial: "notice_no_results" %>
+  <% end %>
 </div>
 <%= paginate(@posts) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
     end
   end
   resources :posts, only: [:new, :create, :destroy, :edit, :update] do
+    collection do
+      get "search"
+    end
     resource :bookmarks, only: [:create, :destroy]
   end
 end


### PR DESCRIPTION
# what
- 投稿の内容を検索する機能を実装した
    - postsコントローラーにsearchアクションを付けて検索機能を担わせた
    - ビューのform_withヘルパーメソッドにて送信のhttpメソッドをgetに指定し、検索キーワードがurlに表示されるようにした
    - postモデルにsearchメソッドを追加してwhere句でのクエリを実行するようにした
    - 検索結果にもkaminariのページネーションを適用した
    - 検索結果で該当無しの場合のテンプレートを作成した
    - キーワードを入力していない場合にJavaScriptで送信を抑止するようにした
    
# why
- 検索機能が無いと過去の投稿を探すことが難しく、実用性を損なうから。

