### PR TITLE
ナビゲーションバーを画面上部に固定した

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,9 +2,16 @@
 @import "font-awesome";
 @import "config/reset";
 @import "bootstrap";
+// 以下でユーザー定義のスタイルをインポートする
+// variables
+@import "config/variables";
+// mixins
+@import "config/mixins";
+// modules
 @import "module/devise_form";
 @import "module/users";
 @import "module/posts";
 @import "module/post_form";
 @import "module/flash";
 @import "module/pagination";
+@import "module/header_navbar";

--- a/app/assets/stylesheets/config/_mixins.scss
+++ b/app/assets/stylesheets/config/_mixins.scss
@@ -1,0 +1,7 @@
+@mixin fix-on-top($top) {
+  position: fixed;
+  top: $top;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+}

--- a/app/assets/stylesheets/config/_variables.scss
+++ b/app/assets/stylesheets/config/_variables.scss
@@ -1,0 +1,4 @@
+// length
+$navbar-height: 56px;
+$mypage-header-height: 80px;
+// color

--- a/app/assets/stylesheets/module/_header_navbar.scss
+++ b/app/assets/stylesheets/module/_header_navbar.scss
@@ -2,4 +2,7 @@
   &__fix-navbar {
     @include fix-on-top(0);
   }
+  &__fix-mypage-header {
+    @include fix-on-top($navbar-height);
+  }
 }

--- a/app/assets/stylesheets/module/_header_navbar.scss
+++ b/app/assets/stylesheets/module/_header_navbar.scss
@@ -1,0 +1,5 @@
+.header {
+  &__fix-navbar {
+    @include fix-on-top(0);
+  }
+}

--- a/app/assets/stylesheets/module/_posts.scss
+++ b/app/assets/stylesheets/module/_posts.scss
@@ -1,5 +1,15 @@
-.posts {
+%posts {
   padding-top: 1rem;
+}
+.posts {
+  &-mypage {
+    @extend %posts;
+    margin-top: $navbar-height + $mypage-header-height;
+  }
+  &-timeline {
+    @extend %posts;
+    margin-top: $navbar-height;
+  }
   %__card {
     max-width: 32rem;
     margin-bottom: 0.5rem;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_new_post, only: [:new, :create]
   before_action :set_post, only: [:edit, :update]
 

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,9 +4,11 @@ class RelationshipsController < ApplicationController
   before_action :redirect_if_user_nil, only: [:create, :destroy]
 
   def followers
+    @users = @user.followers
   end
 
   def followings
+    @users = @user.followings
   end
 
   def create

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,11 +4,11 @@ class RelationshipsController < ApplicationController
   before_action :redirect_if_user_nil, only: [:create, :destroy]
 
   def followers
-    @users = @user.followers
+    @users = pagenate(@user.followers)
   end
 
   def followings
-    @users = @user.followings
+    @users = pagenate(@user.followings)
   end
 
   def create
@@ -62,5 +62,13 @@ class RelationshipsController < ApplicationController
 
   def redirect_if_user_nil
     redirect_back(fallback_location: root_path) and return unless @user
+  end
+
+  def pagenate(users)
+    if users
+      users.order(created_at: :desc).page(params[:page]).per(10)
+    else
+      Kaminari.paginate_array([]).page(1)
+    end
   end
 end

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,6 +1,1 @@
-<%= render partial: "shared/mypage_menubar" %>
-
-<div class="posts">
-  <%= render partial: "shared/post_card", collection: @posts, as: :post %>
-</div>
-<%= paginate(@posts) %>
+<%= render partial: "shared/mypage" %>

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-sm navbar-light bg-light">
+<nav class="navbar navbar-expand-sm navbar-light bg-light header__fix-navbar">
   <%= link_to "Twitter Clone", root_path, class:"navbar-brand" %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/app/views/posts/_notice_no_results.html.erb
+++ b/app/views/posts/_notice_no_results.html.erb
@@ -1,3 +1,3 @@
 <div class="posts__card--no-results mx-auto">
-  <h4><%= "#{@keyword}" %>の検索結果がありません</h4>
+  <h4 class="px-3"><%= "#{@keyword}" %>の検索結果がありません</h4>
 </div>

--- a/app/views/posts/_prompt_new_post.html.erb
+++ b/app/views/posts/_prompt_new_post.html.erb
@@ -1,3 +1,7 @@
 <div class="posts__card--no-results mx-auto">
-  <h4 class="px-3">初めての投稿をしてみませんか？</h4>
+  <h4 class="px-3">
+    <%= link_to new_post_path do %>
+      初めての投稿をしてみませんか？
+    <% end %>
+  </h4>
 </div>

--- a/app/views/posts/_prompt_new_post.html.erb
+++ b/app/views/posts/_prompt_new_post.html.erb
@@ -1,0 +1,3 @@
+<div class="posts__card--no-results mx-auto">
+  <h4 class="px-3">初めての投稿をしてみませんか？</h4>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <%= render "navbar" %>
 <%= render "modal_post_container" %>
-<div class="posts">
+<div class="posts posts-timeline">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
   <% if @posts.empty? %>
     <%= render partial: "prompt_new_post" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,5 +2,8 @@
 <%= render "modal_post_container" %>
 <div class="posts">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
+  <% if @posts.empty? %>
+    <%= render partial: "prompt_new_post" %>
+  <% end %>
 </div>
 <%= paginate(@posts) %>

--- a/app/views/relationships/followers.html.erb
+++ b/app/views/relationships/followers.html.erb
@@ -1,5 +1,1 @@
-<%= render partial: "shared/mypage_menubar" %>
-
-<div class="posts">
-  <%= render partial: "follower_card", collection: @user.followers, as: :user %>
-</div>
+<%= render partial: "shared/mypage_follower" %>

--- a/app/views/relationships/followings.html.erb
+++ b/app/views/relationships/followings.html.erb
@@ -1,5 +1,1 @@
-<%= render partial: "shared/mypage_menubar" %>
-
-<div class="posts">
-  <%= render partial: "follower_card", collection: @user.followings, as: :user %>
-</div>
+<%= render partial: "shared/mypage_follower" %>

--- a/app/views/shared/_mypage.html.erb
+++ b/app/views/shared/_mypage.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "shared/mypage_menubar" %>
 
-<div class="posts">
+<div class="posts posts-mypage">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
 </div>
 <%= paginate(@posts) %>

--- a/app/views/shared/_mypage.html.erb
+++ b/app/views/shared/_mypage.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "shared/mypage_menubar" %>
+
+<div class="posts">
+  <%= render partial: "shared/post_card", collection: @posts, as: :post %>
+</div>
+<%= paginate(@posts) %>

--- a/app/views/shared/_mypage_follower.html.erb
+++ b/app/views/shared/_mypage_follower.html.erb
@@ -3,3 +3,4 @@
 <div class="posts posts-mypage">
   <%= render partial: "follower_card", collection: @users, as: :user %>
 </div>
+<%= paginate(@users) %>

--- a/app/views/shared/_mypage_follower.html.erb
+++ b/app/views/shared/_mypage_follower.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "shared/mypage_menubar" %>
 
-<div class="posts">
+<div class="posts posts-mypage">
   <%= render partial: "follower_card", collection: @users, as: :user %>
 </div>

--- a/app/views/shared/_mypage_follower.html.erb
+++ b/app/views/shared/_mypage_follower.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "shared/mypage_menubar" %>
+
+<div class="posts">
+  <%= render partial: "follower_card", collection: @users, as: :user %>
+</div>

--- a/app/views/shared/_mypage_menubar.html.erb
+++ b/app/views/shared/_mypage_menubar.html.erb
@@ -1,6 +1,6 @@
+<%= render "posts/navbar" %>
+<%= render "posts/modal_post_container" %>
 <div class="header">
-  <%= render "posts/navbar" %>
-  <%= render "posts/modal_post_container" %>
   <div class="header__user-info">
     <div class="header__user-info__inner">
       <div class="header__user-info__inner__user-name">

--- a/app/views/shared/_mypage_menubar.html.erb
+++ b/app/views/shared/_mypage_menubar.html.erb
@@ -1,6 +1,6 @@
 <%= render "posts/navbar" %>
 <%= render "posts/modal_post_container" %>
-<div class="header">
+<div class="header header__fix-mypage-header">
   <div class="header__user-info">
     <div class="header__user-info__inner">
       <div class="header__user-info__inner__user-name">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,1 @@
-<%= render partial: "shared/mypage_menubar" %>
-
-<div class="posts">
-  <%= render partial: "shared/post_card", collection: @posts, as: :post %>
-</div>
-<%= paginate(@posts) %>
+<%= render partial: "shared/mypage" %>

--- a/config/locales/kaminari.ja.yml
+++ b/config/locales/kaminari.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  helpers:
+    page_entries_info:
+      more_pages:
+        display_entries: "<b>%{total}</b>中の%{entry_name}を表示しています <b>%{first} - %{last}</b>"
+      one_page:
+        display_entries:
+          one: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          other: "<b>%{count}</b>レコード表示中です %{entry_name}"
+          zero: "レコードが見つかりませんでした %{entry_name}"
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      next: "次 &rsaquo;"
+      previous: "&lsaquo; 前"
+      truncate: "&hellip;"


### PR DESCRIPTION
# what
- ナビゲーションバーを画面上部に固定し、スクロールしてもナビゲーションバーが上部に表示されるようにした。
- その他の細かな修正
    - タイムラインに何も表示されない場合、「初めての投稿をしてみませんか？」というメッセージを表示
    - postsコントローラーのbefore_actionでdeviseのauthenticateを実行しログインユーザでなければログイン画面にリダイレクトするようにした。
    - kaminariの画面遷移リンクの表示言語を日本語にした
    - フォロワーとフォロー一覧にkaminariのページネーションを適用した
    
# why
- スクロール時にナビゲーションバーが隠れてしまうと、マイページに移動したい場合に不便だから。
