### PR TITLE
バグ修正：検索結果画面で投稿記事がナビゲーションバーにめり込む問題を解消

### DIFF
--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,6 +1,6 @@
 <%= render "navbar" %>
 <%= render "modal_post_container" %>
-<div class="posts">
+<div class="posts posts-timeline">
   <%= render partial: "shared/post_card", collection: @posts, as: :post %>
   <% if @posts.empty? %>
     <%= render partial: "notice_no_results" %>


### PR DESCRIPTION
# what
- ナビゲーションバーはposition: fixedで画面上部に固定しており、投稿記事がめり込む問題があった。これを解消するために上部にマージンをつけた。

# why
- 検索結果画面の見栄えを直すため
