### PR TITLE
非モーダルの投稿フォームがナビゲーションバーに隠れてしまう問題を解消

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,4 +1,5 @@
-$(function() {
+var $;
+$(document).on("turbolinks:load", function() {
   $("#search-posts").on("submit", function() {
     var input = $(this).find("input[type='text']");
     if (input.val().trim().length == 0) {

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -1,8 +1,16 @@
-.post-form {
+%post-form {
   display: flex;
   justify-content: center;
+}
+
+.post-form {
+  @extend %post-form;
   padding: 1rem 1rem 0;
   margin-top: $navbar-height;
+  &-modal {
+  padding: 0.5rem 1rem 0;
+  @extend %post-form;
+  }
   &__form {
     flex-basis: 32rem;
     &__content {

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -1,7 +1,8 @@
 .post-form {
   display: flex;
   justify-content: center;
-  padding: 0.5rem 1rem 0;
+  padding: 1rem 1rem 0;
+  margin-top: $navbar-height;
   &__form {
     flex-basis: 32rem;
     &__content {

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -7,7 +7,7 @@
       </button>
     </div>
     <div class="modal-body">
-      <div class="post-form">
+      <div class="post-form-modal">
         <%= form_with model: @post, class: "post-form__form" do |form| %>
           <div class="post-form__form__menu">
             <%= form.submit button, class: "post-form__form__menu__submit btn btn-primary" %>

--- a/app/views/posts/_prompt_new_post.html.erb
+++ b/app/views/posts/_prompt_new_post.html.erb
@@ -1,6 +1,6 @@
 <div class="posts__card--no-results mx-auto">
   <h4 class="px-3">
-    <%= link_to new_post_path do %>
+    <%= link_to new_post_path, remote: true do %>
       初めての投稿をしてみませんか？
     <% end %>
   </h4>


### PR DESCRIPTION
# what
- ナビゲーションバーをposition: fixed にした影響で非モーダルの投稿フォームが隠れてしまう問題があったため、scssにてmerginを設定して問題を解消した
- これに関連して、モーダルと非モーダルの投稿フォームでmerginに関して異なる設定をした
- 最初の投稿を促すメッセージのリンクからの投稿も非同期でモーダルフォームを出すようにした。
- 細かい修正: 検索フォームの送信を未入力時に抑止するJavaScriptイベントをturbolink:loadに付けた。

# why
- ナビゲーションバーを上部に固定したことに伴うスタイルの修正が行き届いていなかったため。
