### PR TITLE
最初の投稿を促すメッセージを投稿ボタンクリック後に削除する

### DIFF
--- a/app/assets/javascripts/first-post.js
+++ b/app/assets/javascripts/first-post.js
@@ -1,0 +1,6 @@
+var $;
+$(document).on("turbolinks:load", function() {
+  $("#prompt-first-post a").on("click", function() {
+    $("#prompt-first-post").remove();
+  });
+});

--- a/app/assets/javascripts/first-post.js
+++ b/app/assets/javascripts/first-post.js
@@ -1,6 +1,6 @@
 var $;
 $(document).on("turbolinks:load", function() {
-  $("#prompt-first-post a").on("click", function() {
+  $("#prompt-first-post a, #new-post").on("click", function() {
     $("#prompt-first-post").remove();
   });
 });

--- a/app/views/posts/_navbar.html.erb
+++ b/app/views/posts/_navbar.html.erb
@@ -7,7 +7,7 @@
     <ul class="navbar-nav">
       <% if user_signed_in? %>
         <li class="nav-item">
-          <%= link_to "投稿", new_post_path, remote: true, class: "nav-link" %>
+          <%= link_to "投稿", new_post_path, remote: true, class: "nav-link", id: "new-post" %>
         </li>
         <li class="nav-item">
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link" %>

--- a/app/views/posts/_prompt_new_post.html.erb
+++ b/app/views/posts/_prompt_new_post.html.erb
@@ -1,4 +1,4 @@
-<div class="posts__card--no-results mx-auto">
+<div class="posts__card--no-results mx-auto" id="prompt-first-post">
   <h4 class="px-3">
     <%= link_to new_post_path, remote: true do %>
       初めての投稿をしてみませんか？


### PR DESCRIPTION
# what
- タイムラインにコンテンツが存在しない場合、最初の投稿を促すメッセージを出しているが、一度投稿ボタンを押したら、そのメッセージを削除するようにした。

# why
- 投稿ボタンを一度押したユーザーに対して、「最初の投稿を促すメッセージ」を表示し続けるのは煩わしく感じられるから。
