### PR TITLE
Basic認証の有無を環境変数で切り替えるようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,9 @@ class ApplicationController < ActionController::Base
   end
 
   def production?
-    Rails.env.production?
+    if Rails.env.production?
+      true unless ENV["BASIC_AUTH"] && (ENV["BASIC_AUTH"] == "false")
+    end
   end
 
   def basic_auth


### PR DESCRIPTION
# what
- 環境変数でheroku config:set BASIC_AUTH=falseと明示した場合にはBasic認証をオフにする

# why
- s3の利用状況をAWS cloudwatchで監視するようにしたので、不特定多数に利用されても問題ないと判断したため