### PR TITLE
投稿画像のプレビュー機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ db/seeds/temp_*.rb
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# remove private note
+readme.txt

--- a/app/assets/javascripts/preview-image.js
+++ b/app/assets/javascripts/preview-image.js
@@ -19,6 +19,14 @@ $(document).on("turbolinks:load", function() {
     $("#remove-preview-button").hide();
   }
 
+  function checkOnFileRemove() {
+    $("#post_remove_image").prop("checked", true);
+  }
+
+  function checkOffFileRemove() {
+    $("#post_remove_image").prop("checked", false);
+  }
+
   $("#modal-post").on("show.bs.modal", function() {
     if ($(".post-form__preview-image").length != 0) {
       showRemoveButton();
@@ -31,6 +39,7 @@ $(document).on("turbolinks:load", function() {
     $("#post_image").val("");
     $(".post-form__preview-image").remove();
     showUploadIcon();
+    checkOnFileRemove();
   });
 
   $("body").on("change", "#post_image", function() {
@@ -43,5 +52,6 @@ $(document).on("turbolinks:load", function() {
     };
     fileReader.readAsDataURL(file);
     showRemoveButton();
+    checkOffFileRemove();
   });
 });

--- a/app/assets/javascripts/preview-image.js
+++ b/app/assets/javascripts/preview-image.js
@@ -1,0 +1,47 @@
+var $;
+$(document).on("turbolinks:load", function() {
+  function buildPreviewItem(src, alt) {
+    var template = `
+      <div class="post-form__preview-image">
+        <img alt="${alt}" src="${src}">
+      </div>
+    `;
+    return template;
+  }
+
+  function showRemoveButton() {
+    $("#upload-icon").hide();
+    $("#remove-preview-button").show();
+  }
+
+  function showUploadIcon() {
+    $("#upload-icon").show();
+    $("#remove-preview-button").hide();
+  }
+
+  $("#modal-post").on("show.bs.modal", function() {
+    if ($(".post-form__preview-image").length != 0) {
+      showRemoveButton();
+    } else {
+      showUploadIcon();
+    }
+  });
+
+  $("body").on("click", "#remove-preview-button", function() {
+    $("#post_image").val("");
+    $(".post-form__preview-image").remove();
+    showUploadIcon();
+  });
+
+  $("body").on("change", "#post_image", function() {
+    var file = this.files[0];
+    var fileReader = new FileReader();
+
+    fileReader.onload = function(e) {
+      var html = buildPreviewItem(e.target.result, file.name);
+      $(".post-form-preview").prepend(html);
+    };
+    fileReader.readAsDataURL(file);
+    showRemoveButton();
+  });
+});

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -15,10 +15,15 @@
     flex-basis: 32rem;
     &__content {
       &__image {
-        font-size: 1.8rem;
+        font-size: 2rem;
         margin: 0.5rem;
         &:hover {
           cursor: pointer;
+        }
+        &__icon {
+          &:hover {
+            color: #808080;
+          }
         }
         &__field {
           display: none;

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -28,6 +28,9 @@
         &__field {
           display: none;
         }
+        &__remove {
+          display: none;
+        }
       }
     }
     &__menu {

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -8,8 +8,8 @@
   padding: 1rem 1rem 0;
   margin-top: $navbar-height;
   &-modal {
-  padding: 0.5rem 1rem 0;
-  @extend %post-form;
+    padding: 0.5rem 1rem 0;
+    @extend %post-form;
   }
   &__form {
     flex-basis: 32rem;
@@ -35,5 +35,17 @@
         margin: 0.5rem;
       }
     }
+  }
+  &__preview-image {
+    padding: 5px;
+    text-align: center;
+    &:hover {
+      background-color: #b89f9f;
+    }
+  }
+  &__preview-menus {
+    padding: 5px 0;
+    display: flex;
+    justify-content: center;
   }
 }

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -47,9 +47,6 @@
   &__preview-image {
     padding: 5px;
     text-align: center;
-    &:hover {
-      background-color: #b89f9f;
-    }
   }
   &__preview-menus {
     padding: 5px 0;

--- a/app/assets/stylesheets/module/_posts.scss
+++ b/app/assets/stylesheets/module/_posts.scss
@@ -42,6 +42,7 @@
           &__menu {
             a {
               text-decoration: none;
+              display: block;
             }
           }
         }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -93,7 +93,7 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:content, :image).merge(user_id: current_user.id)
+    params.require(:post).permit(:content, :image, :remove_image).merge(user_id: current_user.id)
   end
 
   def pagenate(posts)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,4 +19,10 @@ class Post < ApplicationRecord
     return if keyword.size == 0
     Post.where("content like ?", "%#{keyword}%")
   end
+
+  def remove_image=(val)
+    if val == "1"
+      self.image = nil
+    end
+  end
 end

--- a/app/uploaders/picture_uploader.rb
+++ b/app/uploaders/picture_uploader.rb
@@ -48,6 +48,10 @@ class PictureUploader < CarrierWave::Uploader::Base
     %w(jpg jpeg gif png)
   end
 
+  def content_type_whitelist
+    /image\//
+  end
+
   def size_range
     1..(Settings.carrierwave&.size_upper_limit || 500).kilobytes
   end

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -26,6 +26,9 @@
         <div class="post-form__preview-image">
           <%= image_tag @post.image.url %>
         </div>
+        <div class="post-form__preview-menus">
+          <button type="button" class="btn btn-outline-primary">削除</button>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -22,6 +22,11 @@
           </div>
         <% end %>
       </div>
+      <% if @post.image.present? %>
+        <div class="post-form__preview-image">
+          <%= image_tag @post.image.url %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -22,14 +22,16 @@
           </div>
         <% end %>
       </div>
-      <% if @post.image.present? %>
-        <div class="post-form__preview-image">
-          <%= image_tag @post.image.url %>
-        </div>
-        <div class="post-form__preview-menus">
-          <button type="button" class="btn btn-outline-primary">削除</button>
-        </div>
-      <% end %>
+      <div class="post-form-preview">
+        <% if @post.image.present? %>
+          <div class="post-form__preview-image">
+            <%= image_tag @post.image.url %>
+          </div>
+          <div class="post-form__preview-menus">
+            <button type="button" class="btn btn-outline-primary">削除</button>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -18,6 +18,7 @@
             <%= form.label :image, class: "post-form__form__content__image" do%>
               <%= icon("fas", "image", class: "post-form__form__content__image__icon", id: "upload-icon") %>
               <%= form.file_field :image, class: "post-form__form__content__image__field" %>
+              <%= form.check_box :remove_image, class: "post-form__form__content__image__remove" %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -16,7 +16,7 @@
           <div class="post-form__form__content">
             <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>
             <%= form.label :image, class: "post-form__form__content__image" do%>
-              <%= icon("fas", "image") %>
+              <%= icon("fas", "image", class: "post-form__form__content__image__icon") %>
               <%= form.file_field :image, class: "post-form__form__content__image__field" %>
             <% end %>
           </div>

--- a/app/views/posts/_modal_post_form.html.erb
+++ b/app/views/posts/_modal_post_form.html.erb
@@ -16,7 +16,7 @@
           <div class="post-form__form__content">
             <%= form.text_area :content, rows: 3, class: "form-control post-form__form__content__text", placeholder: "メッセージ" %>
             <%= form.label :image, class: "post-form__form__content__image" do%>
-              <%= icon("fas", "image", class: "post-form__form__content__image__icon") %>
+              <%= icon("fas", "image", class: "post-form__form__content__image__icon", id: "upload-icon") %>
               <%= form.file_field :image, class: "post-form__form__content__image__field" %>
             <% end %>
           </div>
@@ -27,10 +27,10 @@
           <div class="post-form__preview-image">
             <%= image_tag @post.image.url %>
           </div>
-          <div class="post-form__preview-menus">
-            <button type="button" class="btn btn-outline-primary">削除</button>
-          </div>
         <% end %>
+        <div class="post-form__preview-menus">
+          <button type="button" class="btn btn-outline-primary" id="remove-preview-button">削除</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# what
- 画像の投稿画面にて、アップロードする画像のプレビューを表示するようにした
- 画像の編集画面にて、既に投稿済みの画像があればそれをプレビュー表示するようにした
- 画像の編集画面で既存の画像を削除できるようにした

# why
- 画像のプレビュー機能がないと、投稿時に画像をアップロード済みかどうかが利用者に分かりづらいため