### PR TITLE
プロフィール編集でバリデーションエラーのメッセージを表示

### DIFF
--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -12,6 +12,9 @@
     padding: 0.5rem 1rem 0;
     @extend %post-form;
   }
+  &__error-messages {
+    color: red;
+  }
   &__form {
     &__content {
       &__image {
@@ -118,7 +121,6 @@
   }
 
   &__bg-image {
-
     height: 200px;
     width: 100%;
     background-size: cover;

--- a/app/assets/stylesheets/module/_post_form.scss
+++ b/app/assets/stylesheets/module/_post_form.scss
@@ -81,6 +81,9 @@
     position: absolute;
     z-index: 2;
     top: 0;
+    &:hover {
+      cursor: pointer;
+    }
   }
   &__thumbnail-icon {
     &--upload {

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -17,9 +17,9 @@
       <%= form.text_area :profile, rows: 3, class: "form-control post-form__form__content__text", placeholder: "プロフィール" %>
       <section class="post-form__profile-image-section">
         <div class="post-form__thumbnail-container" id="thumbnail-container">
-          <%= icon("fas", "camera", class: "post-form__thumbnail-icon--upload", id: "thumbnail-upload-icon") %>
           <%= icon("far", "window-close", class: "post-form__thumbnail-icon--remove", id: "thumbnail-remove-icon") %>
           <%= form.label :thumbnail, class: "post-form__thumbnail-label" do %>
+            <%= icon("fas", "camera", class: "post-form__thumbnail-icon--upload", id: "thumbnail-upload-icon") %>
             <%= image_tag "icons/user-account.jpeg", class: "post-form__thumbnail-image--default", id: "thumbnail-default" %>
           <% end %>
           <% if @user_profile.thumbnail.present? %>

--- a/app/views/user_profiles/edit.html.erb
+++ b/app/views/user_profiles/edit.html.erb
@@ -1,6 +1,13 @@
 <%= render partial: "posts/navbar" %>
 <div class="post-form">
   <h4 class="text-center pt-3">プロフィール編集</h4>
+  <% unless @user_profile.errors.empty?  %>
+    <ul class="post-form__error-messages">
+      <% @user_profile.errors.full_messages.each do |message| %>
+        <%= content_tag(:li, message) %>
+      <% end %>
+    </ul>
+  <% end %>
   <%= form_with model: @user_profile, url: user_profiles_path, local: true, class: "post-form__form" do |form| %>
     <div class="post-form__form__menu">
       <%= form.submit "保存" , class: "post-form__form__menu__submit btn btn-primary" %>


### PR DESCRIPTION
# what
- プロフィール画面で投稿した画像サイズが大きすぎるとバリデーションエラーとなるが、これが利用者に表示されるようにした。
- プロフィールのサムネイル投稿ボタンの真上でクリックできない問題を解消した

# why
- バリデーションに失敗した理由がユーザーに示されないと、アプリ側の不具合だと誤解されるので、バリデーションメッセージを表示した。
